### PR TITLE
Bugfix/add NOT_EQUAL token

### DIFF
--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/EnemyLexer.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/EnemyLexer.cs
@@ -47,6 +47,7 @@ public partial class EnemyLexer {
         { TokenType.GREATER_EQUAL, ">=" },
         { TokenType.LESS_EQUAL, "<=" },
         { TokenType.EQUAL, "==" },
+        { TokenType.NOT_EQUAL, "!=" },
         { TokenType.PLUS, "+" },
         { TokenType.SUB, "-" },
         { TokenType.MULTIPLY, "*" },

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
@@ -63,6 +63,7 @@ public struct ScriptToken
 
         ASSIGNMENT,
         EQUAL,
+        NOT_EQUAL,
         COMMA,
 
         SYMBOL_ID,


### PR DESCRIPTION
# 発生した問題
`EnemyLexer`において、論理演算子`not`が定義されていたものの、二項比較演算子を表すトークン`!=`が定義されていませんでした。

# やったこと
このトークンの名前を`NOT_EQUAL`と名付け字句解析器が扱う辞書にNOT_EQUAL:`!=`を追加しました。

確認よろしくお願いいたします。