### PR TITLE
Bugfix/lost reference in token stream checker

### DIFF
--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseResult.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseResult.cs
@@ -48,7 +48,7 @@ public struct ParseResult<N> where N:notnull
 
     public ParseResult<N> ApplyIfSucceeded(ref TokenStream stream)
     {
-        if (IsSucceeded()) stream = TokenStream.FromPointer(pointerWhenParseFinished);
+        if (IsSucceeded()) stream.RestartStreamFrom(pointerWhenParseFinished);
         return this;
     }
     public ParseResult<N> ShouldSucceed()

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/TokenStream.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/TokenStream.cs
@@ -15,6 +15,11 @@ public class TokenStream
     public static TokenStream FromPointer(TokenStreamPointer pointer) => new(pointer.sequence, pointer.index);
     public TokenStreamPointer CurrentPointer => new(sequence, index);
 
+    public void RestartStreamFrom(TokenStreamPointer p)
+    {
+        if (this.sequence.Equals(p.sequence)) throw new Exception("Can not restart on the different token sequence.");
+        index = p.index;
+    }
 
     public ScriptToken Read()
     {


### PR DESCRIPTION
# 発生した問題
`ParseResult#ApplyIfSucceeded`を使用すると、元あるTokenStreamへの参照が失われるバグが発生しました。この問題のため、チェーンコードが一式打ち終わると、ストリームの進捗が失われたりするバグや、無限ループを発生させるバグが発生していました。

# やったこと
`ParseResult#ApplyIfSucceeded`で利用されていた`FromPointer`が原因だったので、それとは別に対象のストリームのインデックスを直接書き換える`RestartStreamFrom`を実装し、そちらを使用するようにしています。