### PR TITLE
Feature/add eof token

### DIFF
--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
@@ -67,7 +67,9 @@ public struct ScriptToken
 
         SYMBOL_ID,
         INT_LITERAL,
-        FLOAT_LITERAL
+        FLOAT_LITERAL,
+
+        END_OF_FILE
 
     };
 

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
@@ -25,6 +25,7 @@ public struct ScriptToken
                 return GenerateReservedToken(token);
         }
     }
+    public static ScriptToken EndOfFile => new(){ type = Type.END_OF_FILE };
     public enum Type
     {
         NONE,

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/TokenStream.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/TokenStream.cs
@@ -23,7 +23,7 @@ public class TokenStream
 
     public ScriptToken Read()
     {
-        if (CurrentPointer.OnTerminal()) throw new Exception("This Pointer is on the terminal. Therefore you can't proceed with the pointer any longer.");
+        if (CurrentPointer.OnTerminal()) return ScriptToken.EndOfFile;
         return sequence[index++];
     }
     public ScriptToken Lookahead() => sequence[index];


### PR DESCRIPTION
# 問題
コンパイラが末尾のトークンでバックトラックを発生させた際にTokenStreamのポインタが終点にあるエラーメッセージが出力させていました。
これは、例えばコード`-1`において、演算子`*`が続くか否かを判定するべくバックトラックをすると、エラーが起こるケースなどが上げられます。

# 解決法
`ScriptToken`の`Type`に新たに`END_OF_FILE`というトークンを追加し、終端で読み進めよう(`Read`)とした際にこのトークンが出力されるようになりました。