### PR TITLE
Feature/more detailed error message

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -520,7 +520,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "behavior enemy001 {\n  bullet >>\n       ID: 0\n            generate_bullets(24)\n           
+  m_Text: "behavior enemy001 {\n  bullet >>\n      ID : 0\n            generate_bullets(24)\n           
     set_bullets_position_at_enemy(0)\n            scatter_bullets_in_circular_pattern(0.1f,
     0f)\n            delay_bullets(60)\n            scatter_bullets_in_circular_pattern(0.1f,
     180f)\n            delay_bullets(120)\n\n       ID: 1\n            generate_bullets(24)\n           

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -520,7 +520,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
-  m_Text: "behavior enemy001 {\n  bullet >>\n      ID : 0\n            generate_bullets(24)\n           
+  m_Text: "behaviour enemy001 {\n  bullet >>\n      ID : 0\n            generate_bullets(24)\n           
     set_bullets_position_at_enemy(0)\n            scatter_bullets_in_circular_pattern(0.1f,
     0f)\n            delay_bullets(60)\n            scatter_bullets_in_circular_pattern(0.1f,
     180f)\n            delay_bullets(120)\n\n       ID: 1\n            generate_bullets(24)\n           

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/EnemyLexer.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/EnemyLexer.cs
@@ -110,7 +110,7 @@ public partial class EnemyLexer {
         }
 
         var lineCount = 0;
-        var columnCount = 0;
+        var columnCount = 0; var tokenStartingColumnNumber = 0;
         var codeCharNumber = code.Length;
         
         var tokens = new List<ScriptToken>();
@@ -122,15 +122,16 @@ public partial class EnemyLexer {
             char nextChar = code[textPointer + 1];
             if (currentChar == '\n')
             {
-                lineCount++; columnCount = 0;
+                lineCount++; columnCount = 0; tokenStartingColumnNumber = 0;
                 continue;
             }
-            columnCount++;
+            columnCount++; 
 
             if (shouldSkippedCurrentCharacter(snippet, currentChar)) continue;
             snippet += currentChar;
             if (!existPossibleTokenWhenLookaheading(snippet, nextChar)){
-                tokens.Add(ConvertCurrentSnippetToToken(snippet, lineCount, code, lineCount, columnCount));
+                tokenStartingColumnNumber = columnCount;
+                tokens.Add(ConvertCurrentSnippetToToken(snippet, lineCount, code, lineCount, columnCount - tokenStartingColumnNumber));
                 snippet = "";
             }
         }

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/EnemyLexer.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/EnemyLexer.cs
@@ -110,7 +110,7 @@ public partial class EnemyLexer {
         }
 
         var lineCount = 0;
-        var columnCount = 0; var tokenStartingColumnNumber = 0;
+        var columnCount = 0;
         var codeCharNumber = code.Length;
         
         var tokens = new List<ScriptToken>();
@@ -122,23 +122,23 @@ public partial class EnemyLexer {
             char nextChar = code[textPointer + 1];
             if (currentChar == '\n')
             {
-                lineCount++; columnCount = 0; tokenStartingColumnNumber = 0;
+                lineCount++; columnCount = 0;
                 continue;
             }
-            columnCount++; 
+            columnCount++;
 
             if (shouldSkippedCurrentCharacter(snippet, currentChar)) continue;
             snippet += currentChar;
+
             if (!existPossibleTokenWhenLookaheading(snippet, nextChar)){
-                tokenStartingColumnNumber = columnCount;
-                tokens.Add(ConvertCurrentSnippetToToken(snippet, lineCount, code, lineCount, columnCount - tokenStartingColumnNumber));
+                tokens.Add(ConvertCurrentSnippetToToken(snippet, lineCount, code, columnCount));
                 snippet = "";
             }
         }
 
         if (shouldSkippedCurrentCharacter(snippet, code[codeCharNumber - 1])) return tokens;
         snippet += code[codeCharNumber - 1];
-        tokens.Add(ConvertCurrentSnippetToToken(snippet, lineCount, code, lineCount, columnCount));
+        tokens.Add(ConvertCurrentSnippetToToken(snippet, lineCount, code, columnCount));
         return tokens;
     }
     /**
@@ -154,10 +154,12 @@ public partial class EnemyLexer {
     /**
      * snippetに含まれる文字列をトークン列に変換する
      */
-    ScriptToken ConvertCurrentSnippetToToken(string snippet, int lineCount, string allCode, int lineNumber, int columnNumber)
+    ScriptToken ConvertCurrentSnippetToToken(string snippet, int lineCount, string allCode, int tokenEndColumnNumber)
     {
         var matchedTokenTypeInLastChar = FindOutMatchedTokenTypeInList(snippet, lineCount, allCode);
-        return ScriptToken.GenerateTokenWithPosition(snippet, matchedTokenTypeInLastChar, lineNumber, columnNumber);
+        int length = snippet.Length;
+        TokenRangeInCode tokenRange = new(lineCount, tokenEndColumnNumber - length, length);
+        return ScriptToken.GenerateTokenWithPosition(snippet, matchedTokenTypeInLastChar, tokenRange);
     }
 
     /*

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/EnemyLexer.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/EnemyLexer.cs
@@ -110,6 +110,7 @@ public partial class EnemyLexer {
         }
 
         var lineCount = 0;
+        var columnCount = 0;
         var codeCharNumber = code.Length;
         
         var tokens = new List<ScriptToken>();
@@ -119,19 +120,24 @@ public partial class EnemyLexer {
 
             char currentChar = code[textPointer];
             char nextChar = code[textPointer + 1];
-            if (currentChar == '\n') lineCount++;
-            
+            if (currentChar == '\n')
+            {
+                lineCount++; columnCount = 0;
+                continue;
+            }
+            columnCount++;
+
             if (shouldSkippedCurrentCharacter(snippet, currentChar)) continue;
             snippet += currentChar;
             if (!existPossibleTokenWhenLookaheading(snippet, nextChar)){
-                tokens.Add(ConvertCurrentSnippetToToken(snippet, lineCount, code));
+                tokens.Add(ConvertCurrentSnippetToToken(snippet, lineCount, code, lineCount, columnCount));
                 snippet = "";
             }
         }
 
         if (shouldSkippedCurrentCharacter(snippet, code[codeCharNumber - 1])) return tokens;
         snippet += code[codeCharNumber - 1];
-        tokens.Add(ConvertCurrentSnippetToToken(snippet, lineCount, code));
+        tokens.Add(ConvertCurrentSnippetToToken(snippet, lineCount, code, lineCount, columnCount));
         return tokens;
     }
     /**
@@ -147,10 +153,10 @@ public partial class EnemyLexer {
     /**
      * snippetに含まれる文字列をトークン列に変換する
      */
-    ScriptToken ConvertCurrentSnippetToToken(string snippet, int lineCount, string allCode)
+    ScriptToken ConvertCurrentSnippetToToken(string snippet, int lineCount, string allCode, int lineNumber, int columnNumber)
     {
         var matchedTokenTypeInLastChar = FindOutMatchedTokenTypeInList(snippet, lineCount, allCode);
-        return ScriptToken.GenerateToken(snippet, matchedTokenTypeInLastChar);
+        return ScriptToken.GenerateTokenWithPosition(snippet, matchedTokenTypeInLastChar, lineNumber, columnNumber);
     }
 
     /*

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
@@ -39,10 +39,10 @@ public struct ScriptToken
                 return GenerateReservedToken(token);
         }
     }
-    public static ScriptToken GenerateTokenWithPosition(string snippet, Type token, int lineNumber, int beginColumnNumber, int length)
+    public static ScriptToken GenerateTokenWithPosition(string snippet, Type token, TokenRangeInCode tokenRange)
     {
         ScriptToken scriptToken = GenerateToken(snippet, token);
-        scriptToken.range = new(lineNumber, beginColumnNumber, length);
+        scriptToken.range = tokenRange;
         return scriptToken;
     }
     public static ScriptToken EndOfFile => new(){ type = Type.END_OF_FILE };

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
@@ -6,7 +6,7 @@ public struct TokenRangeInCode
     int lineNumber;
     int beginColumnNumber;
     int length;
-    public TokenRangeInCode(int lineNumber, int beginColumnNumber, int endColumnNumber)
+    public TokenRangeInCode(int lineNumber, int beginColumnNumber, int length)
     {
         this.lineNumber = lineNumber;
         this.beginColumnNumber = beginColumnNumber;
@@ -41,7 +41,6 @@ public struct ScriptToken
     }
     public static ScriptToken GenerateTokenWithPosition(string snippet, Type token, int lineNumber, int beginColumnNumber, int length)
     {
-
         ScriptToken scriptToken = GenerateToken(snippet, token);
         scriptToken.range = new(lineNumber, beginColumnNumber, length);
         return scriptToken;

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
@@ -1,6 +1,18 @@
 ﻿#nullable enable
 using UnityEngine;
 
+public struct TokenRangeInCode
+{
+    int lineNumber;
+    int beginColumnNumber;
+    int length;
+    public TokenRangeInCode(int lineNumber, int beginColumnNumber, int endColumnNumber)
+    {
+        this.lineNumber = lineNumber;
+        this.beginColumnNumber = beginColumnNumber;
+        this.length = length;
+    }
+}
 public struct ScriptToken
 {
     public Type type;
@@ -8,10 +20,7 @@ public struct ScriptToken
     public int int_val;
     public float float_val;
 
-    private int? _lineNumber;
-    private int? _columnNumber;
-    public int? LineNumber { get => _lineNumber; }
-    public int? ColumnNumber { get => _columnNumber; }    
+    public TokenRangeInCode range;
 
     /**
      * 与えられたトークンの情報から適切にトークンを生成する。
@@ -30,12 +39,11 @@ public struct ScriptToken
                 return GenerateReservedToken(token);
         }
     }
-    public static ScriptToken GenerateTokenWithPosition(string snippet, Type token, int lineNumber, int columnNumber)
+    public static ScriptToken GenerateTokenWithPosition(string snippet, Type token, int lineNumber, int beginColumnNumber, int length)
     {
 
         ScriptToken scriptToken = GenerateToken(snippet, token);
-        scriptToken._lineNumber = lineNumber;
-        scriptToken._columnNumber = columnNumber;
+        scriptToken.range = new(lineNumber, beginColumnNumber, length);
         return scriptToken;
     }
     public static ScriptToken EndOfFile => new(){ type = Type.END_OF_FILE };

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
@@ -9,9 +9,9 @@ public struct ScriptToken
     public float float_val;
 
     private int? _lineNumber;
+    private int? _columnNumber;
     public int? LineNumber { get => _lineNumber; }
-    private int? ColumnNumber { get => _columnNumber; }
-    public int? _columnNumber;
+    public int? ColumnNumber { get => _columnNumber; }    
 
     /**
      * 与えられたトークンの情報から適切にトークンを生成する。

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
@@ -3,9 +3,9 @@ using UnityEngine;
 
 public struct TokenRangeInCode
 {
-    int lineNumber;
-    int beginColumnNumber;
-    int length;
+    public int lineNumber;
+    public int beginColumnNumber;
+    public int length;
     public TokenRangeInCode(int lineNumber, int beginColumnNumber, int length)
     {
         this.lineNumber = lineNumber;

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyLexer/ScriptToken.cs
@@ -1,4 +1,4 @@
-﻿
+﻿#nullable enable
 using UnityEngine;
 
 public struct ScriptToken
@@ -7,6 +7,11 @@ public struct ScriptToken
     public string user_defined_symbol;
     public int int_val;
     public float float_val;
+
+    private int? _lineNumber;
+    public int? LineNumber { get => _lineNumber; }
+    private int? ColumnNumber { get => _columnNumber; }
+    public int? _columnNumber;
 
     /**
      * 与えられたトークンの情報から適切にトークンを生成する。
@@ -24,6 +29,14 @@ public struct ScriptToken
             default:
                 return GenerateReservedToken(token);
         }
+    }
+    public static ScriptToken GenerateTokenWithPosition(string snippet, Type token, int lineNumber, int columnNumber)
+    {
+
+        ScriptToken scriptToken = GenerateToken(snippet, token);
+        scriptToken._lineNumber = lineNumber;
+        scriptToken._columnNumber = columnNumber;
+        return scriptToken;
     }
     public static ScriptToken EndOfFile => new(){ type = Type.END_OF_FILE };
     public enum Type

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseException.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseException.cs
@@ -3,6 +3,8 @@
 public class ParseException : Exception
 {
     public ParseException(string message) : base(message) { }
-    public static ParseException Information(string message, TokenStreamPointer pointer)
-        => new(message + $" : at token number {pointer.index}");
+    public static ParseException Information(string message, TokenStreamPointer pointer) {
+        ScriptToken currentToken = pointer.Access();
+        return new(message + $" : at line {currentToken.LineNumber}, column {currentToken.ColumnNumber} token number {pointer.index}");
+    }
 }

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseException.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseException.cs
@@ -4,14 +4,12 @@ public class ParseException : Exception
 {
     public ParseException(string message) : base(message) { }
     public static ParseException Information(string message, TokenStreamPointer pointer) {
-        TokenRangeInCode range = pointer.Access().range;
-        int endColumnNumber = range.length + range.beginColumnNumber;
-        return new(message + $" : at line {range.lineNumber}, column {range.beginColumnNumber} to {endColumnNumber} token number {pointer.index}");
+        return ParseException.Information(message, pointer.Access());
     }
     public static ParseException Information(string message, ScriptToken scriptToken)
     {
         TokenRangeInCode range = scriptToken.range;
         int endColumnNumber = range.length + range.beginColumnNumber;
-        return new(message + $" : at line {range.lineNumber}, column {range.beginColumnNumber} to {endColumnNumber} token number {pointer.index}");
+        return new(message + $" : at line {range.lineNumber}, column {range.beginColumnNumber} to {endColumnNumber}");
     }
 }

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseException.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseException.cs
@@ -8,4 +8,10 @@ public class ParseException : Exception
         int endColumnNumber = range.length + range.beginColumnNumber;
         return new(message + $" : at line {range.lineNumber}, column {range.beginColumnNumber} to {endColumnNumber} token number {pointer.index}");
     }
+    public static ParseException Information(string message, ScriptToken scriptToken)
+    {
+        TokenRangeInCode range = scriptToken.range;
+        int endColumnNumber = range.length + range.beginColumnNumber;
+        return new(message + $" : at line {range.lineNumber}, column {range.beginColumnNumber} to {endColumnNumber} token number {pointer.index}");
+    }
 }

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseException.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseException.cs
@@ -4,7 +4,8 @@ public class ParseException : Exception
 {
     public ParseException(string message) : base(message) { }
     public static ParseException Information(string message, TokenStreamPointer pointer) {
-        ScriptToken currentToken = pointer.Access();
-        return new(message + $" : at line {currentToken.LineNumber}, column {currentToken.ColumnNumber} token number {pointer.index}");
+        TokenRangeInCode range = pointer.Access().range;
+        int endColumnNumber = range.length + range.beginColumnNumber;
+        return new(message + $" : at line {range.lineNumber}, column {range.beginColumnNumber} to {endColumnNumber} token number {pointer.index}");
     }
 }

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseException.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseException.cs
@@ -12,6 +12,6 @@ public class ParseException : Exception
     {
         TokenRangeInCode range = scriptToken.range;
         int endColumnNumber = range.length + range.beginColumnNumber;
-        return new(message + $" : at line {range.lineNumber}, column {range.beginColumnNumber} to {endColumnNumber} token number {pointer.index}");
+        return new(message + $" : at line {range.lineNumber}, column {range.beginColumnNumber} to {endColumnNumber}");
     }
 }

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseException.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/ParseException.cs
@@ -12,6 +12,6 @@ public class ParseException : Exception
     {
         TokenRangeInCode range = scriptToken.range;
         int endColumnNumber = range.length + range.beginColumnNumber;
-        return new(message + $" : at line {range.lineNumber}, column {range.beginColumnNumber} to {endColumnNumber} token number {pointer.index}");
+        return new(message + $" : at line {range.lineNumber}, column {range.beginColumnNumber} to {endColumnNumber} token number {scriptToken.index}");
     }
 }

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/TokenChecker.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/TokenChecker.cs
@@ -55,10 +55,10 @@ public class TokenStreamChecker
         this.initialPointer = initialPointer;
     }
 
-    private void RecognizeFailed(string reason)
+    private void RecognizeFailed(string reason, ScriptToken token)
     {
         isSatisfiedInTheConditionSequence = false;
-        parseException = ParseException.Information(reason, target.CurrentPointer);
+        parseException = ParseException.Information(reason, token);
         target.RecoverPointer(initialPointer);
         if (shouldBeSatisfied) throw parseException;
     }
@@ -66,7 +66,7 @@ public class TokenStreamChecker
     public TokenStreamChecker Expect(string tokenInString)
     {
         var nextToken = target.Read();
-        if (!TheSameTokens(nextToken, tokenInString)) RecognizeFailed($"expected `{tokenInString}` but `{ConvertToString(nextToken)}` is coming.");
+        if (!TheSameTokens(nextToken, tokenInString)) RecognizeFailed($"expected `{tokenInString}` but `{ConvertToString(nextToken)}` is coming.", nextToken);
         return this;
     }
 
@@ -89,14 +89,14 @@ public class TokenStreamChecker
     public TokenStreamChecker ExpectVariable(out ScriptToken captured)
     {
         var nextToken = target.Read();
-        if (!allowedTokenTypeList.Contains(nextToken.type)) RecognizeFailed($"expected something of variable tokens but `{nextToken.type}` is coming.");
+        if (!allowedTokenTypeList.Contains(nextToken.type)) RecognizeFailed($"expected something of variable tokens but `{nextToken.type}` is coming.", nextToken);
         captured = nextToken;
         return this;
     }
     public TokenStreamChecker ExpectSymbolID(out string captured)
     {
         var nextToken = target.Read();
-        if (nextToken.type != ScriptToken.Type.SYMBOL_ID) RecognizeFailed($"expected something of symbolID but `{nextToken.type}` is coming.");
+        if (nextToken.type != ScriptToken.Type.SYMBOL_ID) RecognizeFailed($"expected something of symbolID but `{nextToken.type}` is coming.", nextToken);
         captured = nextToken.user_defined_symbol;
         return this;
     }

--- a/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/TokenPointer.cs
+++ b/Assets/Scripts/Enemy/EnemyInterpreter/EnemyParser/ParserCore/TokenPointer.cs
@@ -25,6 +25,7 @@ public class TokenStreamPointer
     {
         var actualPointer = index + delta;
         if (actualPointer > sequence.Count) throw ParseException.Information($"try to access ${actualPointer} but failed because the token sequence's length is {sequence.Count}.", this);
+        if (actualPointer == sequence.Count) return ScriptToken.EndOfFile;
         return sequence[actualPointer];
     }
     /// <summary>


### PR DESCRIPTION
# モチベーション
今までコンパイラはトークン列の番号によって構文エラーを報告していた。しかしこれでは、コードが長くなった際にエラーの特定が遅れてしまう。よって、その改善を図るためにこの機能追加を行った。

# やったこと
## エラーが発生した際における、行数と列数の報告機能の実装
以下のように、エラーを起こしたトークンを行および列番号で指し示すようなエラーメッセージを通知する機能を作成した。
```
ParseException: expected `behavior` but `behaviour` is coming. : at line 0, column 0 to 9
```
ただ単にトークンを始まる箇所だけで示すのではなく、コード中の範囲として示すような仕様にした。

実装としては、各トークンに現在の所有地を記録したTokenRangeInCodeというオブジェクトを所持してもらうことで、この機能を実装した。

## その他バグ修正
以下について修正を行った。
- `TokenStreamPointer`について、Accessを行ったとき、そのポインタが終端を指していた場合に範囲外アクセスエラーを起こしてしまう挙動
    - 終端を指し示している時には、EOFを返すようにプログラムした。
-  `TokenStreamChecker`トークンがエラーを報告する際、実際にはその先のポインタをエラー発生箇所だと報告していた問題